### PR TITLE
Update to the Post List Search Request

### DIFF
--- a/api-reference/callouts/post-list-search-request.markdown
+++ b/api-reference/callouts/post-list-search-request.markdown
@@ -9,7 +9,7 @@ layout: reference
 application/xml
 
 ## Request URI
-The Fetch List callout sends the attendee information to a URI for the application connector, which can be in a custom location for each client. The standard location is:
+The Fetch List callout sends login user ID and other configured data to the /v1.2/fetch endpoint on the application connector server. The standard location is:
 
     https://{servername}/concur/list/v1.2/fetch
 


### PR DESCRIPTION
Currently it says that the callout sends attendee information to the callout end point

## Pull Request Checklist

**Complete and check all items that are applicable.**

- [x] Proofread documentation changes for spelling and grammatical errors
- [x] Used Markdown code blocks for all applicable examples using code
- [x] Used relative links when linking to other documentation on Developer Center
- [x] If creating new API reference pages, followed the guidelines stated [in the wiki](https://github.com/concur/developer.concur.com/wiki/Creating-API-Reference-pages)
- [x] If moving pages, added [page redirects](https://github.com/concur/developer.concur.com/wiki/Adding-Redirects) so users are redirected to the new page
